### PR TITLE
Label schema bump

### DIFF
--- a/spec/labels.md
+++ b/spec/labels.md
@@ -5,12 +5,13 @@ All labels live in common namespace `io.hica`, each set of labels with defined
 values and name of command line parameter for supplying the value is versioned 
 under `schema` versions. 
 
-## Label Schema v0.1
+## Label Schema v0.2
 
 | Label | Command line | Values | Default Value |
 |-------|--------------|--------|---------------|
 | io.hica.xsocket_passthrough | --xsocket-path, --x-display-num | *path*, *int* | `/tmp/.X11-unix`, `0` |
-| io.hica.dri_passthrough | *none* | *none* | `/dev/dri/*` |
+| io.hica.dri_passthrough | --dri-passthrough-path | *glob* | `/dev/dri/*` |
+| io.hica.machine_id | --machine-id-path | *path* | `/etc/machine-id`|
 | io.hica.cuda | --cuda-device, --cuda-device-ctl, --cuda-device-uvm | *path*, *path*, *path* | `/dev/nvidia0`, `/dev/nvidiactl`, `/dev/nvidia-uvm` |
 | io.hica.sound_device | --sound-device | *glob* | `/dev/snd*` |
 | io.hica.pulse | --pulse-device | *path* | `/run/user/$UID/pulse/` |


### PR DESCRIPTION
- version bump to 0.2
- dri interface clarification
- add machine-id passthrough
