### PR TITLE
Make labelstore available to injectors

### DIFF
--- a/base/hica_base.py
+++ b/base/hica_base.py
@@ -48,7 +48,7 @@ class HicaInjector(object):
         config.append("-e")
         config.append("{0}={1}".format(k, v))
 
-  def inject_config(self, config, from_args):
+  def inject_config(self, config, from_args, labelStore=None):
     for cv in from_args:
       self.inject_value_type(cv, config)
 

--- a/docker-hica
+++ b/docker-hica
@@ -188,7 +188,7 @@ def HicaInjectConfiguration(labels, args, config):
           cfgs.append((typ, x))
         else:
           cfgs.append((typ, defval))
-      inj.inject_config(config, cfgs)
+      inj.inject_config(config, cfgs, labels)
 
   instr = "The container requests the following capabilities: \n - " + "\n - ".join(caps) + "\nProceed? [y/Y/n]: "
   if args.yes or not caps or raw_input(instr) in ['y', 'Y']:

--- a/injectors/bind_pwd.py
+++ b/injectors/bind_pwd.py
@@ -18,8 +18,8 @@ class BindPwdInjector(HicaInjector):
   def get_injected_args(self):
     return ((None, HicaValueType.PATH, os.getenv("PWD")),)
 
-  def inject_config(self, config, args):
-    super(BindPwdInjector, self).inject_config(config, args)
+  def inject_config(self, config, args, labelStore=None):
+    super(BindPwdInjector, self).inject_config(config, args, labelStore)
     # we also set in-container PWD to the same as on the host
     config.append('-w')
     config.append(args[0][1])


### PR DESCRIPTION
Labels can be inspected from custom injectors by overriding the `inject_config` method.
